### PR TITLE
delete the first level of directories

### DIFF
--- a/DriveClean.ps1
+++ b/DriveClean.ps1
@@ -203,7 +203,7 @@ Function Remove-Dir
 
     if ((Test-Path "$path"))
     {
-        Get-ChildItem -Path "$path" -Force -ErrorAction SilentlyContinue | Get-ChildItem -Force -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue -Verbose
+        Get-ChildItem -Path "$path" -Force -Recurse -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue -Verbose
     }
 }
 


### PR DESCRIPTION
Improve the code of the Remove-Dir function, to delete the first level of directories, which were not deleted now.