### PR TITLE
Exclude system profiles from cache cleaning

### DIFF
--- a/DriveClean.ps1
+++ b/DriveClean.ps1
@@ -23,8 +23,16 @@ Function Clear-GlobalWindowsCache
 Function Clear-UserCacheFiles
 {
     # Stop-BrowserSessions
-    ForEach ($localUser in (Get-ChildItem "C:\users").Name)
+    # Use only real user directories
+    $excludedUsers = @("All Users", "Default", "Default User", "Public")
+    ForEach ($userDir in Get-ChildItem "C:\users" -Directory)
     {
+        if ($excludedUsers -contains $userDir.Name)
+        {
+            continue
+        }
+
+        $localUser = $userDir.Name
         Clear-AcrobatCacheFiles $localUser
         Clear-AVGCacheFiles $localUser
         Clear-BattleNetCacheFiles $localUser


### PR DESCRIPTION
## Summary
- skip non-user profile directories when clearing caches
- document exclusion to use only real user directories

## Testing
- `apt-get install -y powershell` *(fails: unable to locate package)*
- `powershell -NoLogo -Command "Get-FileHash -Algorithm MD5 DriveClean.ps1"` *(fails: command not found)*
- `md5sum DriveClean.ps1`


------
https://chatgpt.com/codex/tasks/task_e_689a57b45818832e8436fcf0065d2529