### PR TITLE
Add dry-run and verbose options with deletion summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ e.g. - `cd c:\WindowsClearCache`
 5) Next, to run the script, enter in the following:
 e.g. - `.\DriveClean.ps1`
 
+Optional flags:
+
+- Use `-DryRun` to preview the files that would be deleted without removing them.
+- Use `-Verbose` to display each file as it is deleted (or would be deleted in dry run).
+
 ## Tested on following Windows Versions
 
 Verified on the following platforms:


### PR DESCRIPTION
## Summary
- add optional dry-run flag for previewing deletions
- support verbose mode to list each file removed
- report count of removed files and disk space freed at end
- route Get-ChildItem deletions through Remove-Dir for accurate counting and dry-run support

## Testing
- `pwsh -NoLogo -NoProfile -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `apt-get update`
- `apt-get install -y powershell` *(fails: unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68b47d3ba138832e824774a7b85a6b34